### PR TITLE
Add iOS consumer skills for Mobile SDK integration

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -27,6 +27,7 @@ Use the directory/`SKILL.md` format so the `npx skills` CLI can discover and ins
 | Skill | Description |
 |---|---|
 | `add-mobile-sdk-ios/` | Add Mobile SDK authentication to an existing iOS Swift app |
+| `create-ios-app-with-mobile-sdk/` | Create a new iOS Swift app from scratch with Mobile SDK already integrated |
 
 ### SDK developer skills (internal)
 

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -24,7 +24,9 @@ Use the directory/`SKILL.md` format so the `npx skills` CLI can discover and ins
     SKILL.md
 ```
 
-_No consumer skills yet — add them here._
+| Skill | Description |
+|---|---|
+| `add-mobile-sdk-ios/` | Add Mobile SDK authentication to an existing iOS Swift app |
 
 ### SDK developer skills (internal)
 
@@ -56,6 +58,45 @@ description: What this skill does and when to use it
 # My Skill
 ...
 ```
+
+## Testing a Consumer Skill
+
+Before shipping a new consumer skill, exercise it against a real blank app to verify it produces a working result end-to-end.
+
+### Process
+
+1. **Create a blank app** using `xcodegen` (or Xcode's new project wizard) in a temp directory
+2. **Apply the skill** — run Claude Code in that directory and invoke the skill
+3. **Build** — `xcodebuild` against a simulator to confirm no compile errors
+4. **Run on simulator** — verify the skill's core behaviour (e.g. login screen appears, SDK initializes)
+5. **Clean up** — delete the temp directory after validation
+
+### Example: testing `add-mobile-sdk-ios`
+
+```bash
+# Create blank app
+mkdir /tmp/SkillTest && cd /tmp/SkillTest
+# ... write project.yml, generate with xcodegen ...
+
+# Apply the skill (Claude Code invokes it)
+# Then build:
+xcodebuild -workspace SkillTest.xcworkspace \
+  -scheme SkillTest \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  build
+```
+
+Expected: `** BUILD SUCCEEDED **` and Salesforce login screen on first run.
+
+### What to check
+
+- [ ] Project builds without errors
+- [ ] Login screen appears on first launch
+- [ ] Post-login screen is reachable
+- [ ] No crash on cold start
+
+---
 
 **SDK developer skill** — create a flat `.md` file with `metadata.internal: true`:
 

--- a/.claude/skills/add-mobile-sdk-ios/SKILL.md
+++ b/.claude/skills/add-mobile-sdk-ios/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: add-mobile-sdk-ios
+description: Add Salesforce Mobile SDK to an existing iOS Swift application. Handles dependency (CocoaPods or SPM), SDK initialization, OAuth login flow via AuthHelper, bootconfig.plist, and Info.plist configuration.
+---
+
+# Add Salesforce Mobile SDK to an iOS Swift App
+
+This skill integrates the Salesforce Mobile SDK into an existing iOS Swift application, wiring up authentication so users are prompted to log in to Salesforce when the app launches.
+
+## What This Skill Does
+
+1. Adds the `SalesforceSDKCore` dependency (CocoaPods **or** Swift Package Manager, matching what the app already uses)
+2. Initializes the SDK in `AppDelegate`
+3. Wires `AuthHelper.loginIfRequired` and user-change notifications into `SceneDelegate`
+4. Adds `bootconfig.plist` with OAuth configuration placeholders
+5. Adds the required `SFDCOAuthLoginHost` key to `Info.plist`
+
+## Prerequisites
+
+Before starting, ask the user for:
+- **App target name** (the Xcode target to modify, e.g. `MyApp`)
+- **Consumer Key** (OAuth connected app consumer key, or leave as placeholder)
+- **Callback URL** (OAuth redirect URI, or leave as placeholder)
+- **Login host** (default: `login.salesforce.com`, use `test.salesforce.com` for sandboxes)
+
+Also detect which dependency manager the project uses:
+- Project has a `Podfile` → use the CocoaPods path
+- Project has `.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/` → use the SPM path
+
+---
+
+## Step 1: Add the SDK Dependency
+
+### Option A — CocoaPods (project has a `Podfile`)
+
+Add the Salesforce specs source and `SalesforceSDKCore` pod. `SalesforceSDKCore` pulls in `SalesforceAnalytics` and `SalesforceSDKCommon` transitively, so you only need to declare one pod.
+
+```ruby
+source 'https://cdn.cocoapods.org/'
+source 'https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs'
+
+platform :ios, '18.0'
+
+target 'YourApp' do
+  use_frameworks!
+  pod 'SalesforceSDKCore'
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
+    end
+  end
+end
+```
+
+Then install:
+
+```bash
+pod install
+```
+
+Open `YourApp.xcworkspace` (not `.xcodeproj`) from now on.
+
+> **Adding SmartStore or MobileSync later?** Add `pod 'SmartStore'` or `pod 'MobileSync'` to the same target block. MobileSync depends on SmartStore which depends on SalesforceSDKCore, so adding MobileSync alone is sufficient to pull in everything.
+
+### Option B — Swift Package Manager (project uses SPM)
+
+In Xcode:
+1. **File → Add Package Dependencies…**
+2. Enter: `https://github.com/forcedotcom/SalesforceMobileSDK-iOS-SPM`
+3. Select branch `master` (or the version tag matching your desired SDK release)
+4. Add these products to your app target:
+   - `SalesforceSDKCore`
+   - `SalesforceAnalytics`
+   - `SalesforceSDKCommon`
+
+> **Adding SmartStore or MobileSync later?** From the same package, add `SmartStore` or `MobileSync` to the target's frameworks.
+
+---
+
+## Step 2: Update AppDelegate.swift
+
+The key changes from a plain iOS app:
+- `import SalesforceSDKCore`
+- Call `SalesforceManager.initializeSDK()` in `init()` — must run before any SDK class is used
+
+```swift
+import UIKit
+import SalesforceSDKCore
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    override init() {
+        super.init()
+        SalesforceManager.initializeSDK()
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication,
+                     configurationForConnecting connectingSceneSession: UISceneSession,
+                     options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication,
+                     didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {}
+
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+}
+```
+
+---
+
+## Step 3: Update SceneDelegate.swift
+
+The key Mobile SDK additions:
+- `import SalesforceSDKCore`
+- `AuthHelper.registerBlock(forCurrentUserChangeNotifications:)` in `scene(_:willConnectTo:)` — re-runs your root view controller setup whenever the logged-in user changes (switch user, logout/login)
+- `AuthHelper.loginIfRequired` in `sceneWillEnterForeground` — presents the Salesforce login screen if no valid session exists
+
+```swift
+import UIKit
+import SalesforceSDKCore
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene,
+               willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        window = UIWindow(frame: windowScene.coordinateSpace.bounds)
+        window?.windowScene = windowScene
+
+        AuthHelper.registerBlock(forCurrentUserChangeNotifications: {
+            self.resetViewState {
+                self.setupRootViewController()
+            }
+        })
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        initializeAppViewState()
+        AuthHelper.loginIfRequired {
+            self.setupRootViewController()
+        }
+    }
+
+    // MARK: - Private
+
+    func initializeAppViewState() {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { self.initializeAppViewState() }
+            return
+        }
+        window?.rootViewController = UIViewController()   // splash/loading screen while login is presented
+        window?.makeKeyAndVisible()
+    }
+
+    func setupRootViewController() {
+        // Replace with your post-login root view controller
+        window?.rootViewController = UIViewController()
+    }
+
+    func resetViewState(_ postResetBlock: @escaping () -> Void) {
+        if let root = window?.rootViewController, root.presentedViewController != nil {
+            root.dismiss(animated: false, completion: postResetBlock)
+        } else {
+            postResetBlock()
+        }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {}
+    func sceneDidBecomeActive(_ scene: UIScene) {}
+    func sceneWillResignActive(_ scene: UIScene) {}
+    func sceneDidEnterBackground(_ scene: UIScene) {}
+}
+```
+
+> **`setupRootViewController()`** is called after a successful login and after every user switch. Replace both `UIViewController()` placeholders with your actual screens.
+
+---
+
+## Step 4: Add bootconfig.plist
+
+Create `bootconfig.plist` inside your app target's source folder (next to `Info.plist`), then add it to the Xcode target via **Add Files to "YourApp"**.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>remoteAccessConsumerKey</key>
+    <string>YOUR_CONSUMER_KEY</string>
+    <key>oauthRedirectURI</key>
+    <string>YOUR_CALLBACK_URL</string>
+    <key>shouldAuthenticate</key>
+    <true/>
+</dict>
+</plist>
+```
+
+Replace `YOUR_CONSUMER_KEY` and `YOUR_CALLBACK_URL` with the values from your Salesforce Connected App. If the user provided them in the prerequisites, substitute them now.
+
+Verify `bootconfig.plist` appears in the **Copy Bundle Resources** build phase for the target.
+
+---
+
+## Step 5: Update Info.plist
+
+Add the `SFDCOAuthLoginHost` key to the app target's `Info.plist`:
+
+```xml
+<key>SFDCOAuthLoginHost</key>
+<string>login.salesforce.com</string>
+```
+
+Use the login host provided by the user, or `login.salesforce.com` as the default.
+
+Also ensure the Scene configuration is present (required for `SceneDelegate` to be invoked). If the app was created with Xcode's default template it will already have this — verify `UISceneDelegateClassName` matches your module name:
+
+```xml
+<key>UIApplicationSceneManifest</key>
+<dict>
+    <key>UIApplicationSupportsMultipleScenes</key>
+    <false/>
+    <key>UISceneConfigurations</key>
+    <dict>
+        <key>UIWindowSceneSessionRoleApplication</key>
+        <array>
+            <dict>
+                <key>UISceneConfigurationName</key>
+                <string>Default Configuration</string>
+                <key>UISceneDelegateClassName</key>
+                <string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+            </dict>
+        </array>
+    </dict>
+</dict>
+```
+
+---
+
+## Step 6: Verify the Integration
+
+Build and run. On first launch, the Salesforce login screen should appear. After a successful login, `setupRootViewController()` is called.
+
+### Checklist
+
+- [ ] SDK dependency added and project builds without errors
+- [ ] `SalesforceManager.initializeSDK()` called in `AppDelegate.init()`
+- [ ] `AuthHelper.registerBlock(forCurrentUserChangeNotifications:)` called in `scene(_:willConnectTo:)`
+- [ ] `AuthHelper.loginIfRequired` called in `sceneWillEnterForeground`
+- [ ] `bootconfig.plist` is in the target and in Copy Bundle Resources
+- [ ] `remoteAccessConsumerKey` and `oauthRedirectURI` are set in `bootconfig.plist`
+- [ ] `SFDCOAuthLoginHost` is present in `Info.plist`
+- [ ] App prompts for Salesforce login on first launch
+- [ ] `setupRootViewController()` replaced with the real root view controller
+
+---
+
+## Troubleshooting
+
+**Build error: `Cannot find type 'SalesforceManager'`**
+The import is missing or the framework is not linked. For CocoaPods, verify `pod install` completed and you opened `.xcworkspace`. For SPM, verify `SalesforceSDKCore` is in the target's Frameworks.
+
+**Login screen does not appear**
+Check that `SFDCOAuthLoginHost` is in `Info.plist` and `bootconfig.plist` is included in Copy Bundle Resources.
+
+**Login succeeds but app shows blank screen**
+`setupRootViewController()` still has the placeholder `UIViewController()`. Replace it with your app's actual root view controller.
+
+**`pod install` fails with "Unable to find a specification for `SalesforceSDKCore`"**
+Ensure both sources are declared in the Podfile — `cdn.cocoapods.org` and `github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs`.

--- a/.claude/skills/create-ios-app-with-mobile-sdk/SKILL.md
+++ b/.claude/skills/create-ios-app-with-mobile-sdk/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: create-ios-app-with-mobile-sdk
+description: Create a new iOS Swift application from scratch using xcodegen, then integrate Salesforce Mobile SDK authentication into it.
+---
+
+# Create an iOS App with Salesforce Mobile SDK
+
+This skill creates a new iOS Swift application from scratch using `xcodegen`, then integrates the Salesforce Mobile SDK by invoking the `add-mobile-sdk-ios` skill.
+
+## Prerequisites
+
+Ensure `xcodegen` is installed:
+
+```bash
+brew install xcodegen
+```
+
+Before starting, ask the user for:
+- **App name** (e.g. `MyApp`) — used as the Xcode target name, directory name, and bundle name
+- **Bundle ID** (e.g. `com.mycompany.myapp`)
+- **Output directory** (where to create the project, e.g. `~/Projects`)
+- **Dependency manager**: CocoaPods or Swift Package Manager
+- **Consumer Key**, **Callback URL**, **Login host** — passed through to the `add-mobile-sdk-ios` skill
+
+---
+
+## Step 1: Create the Project Directory and Source Files
+
+```bash
+mkdir -p <OutputDir>/<AppName>/<AppName>
+cd <OutputDir>/<AppName>
+```
+
+Create `<AppName>/AppDelegate.swift`:
+
+```swift
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_ application: UIApplication,
+                     configurationForConnecting connectingSceneSession: UISceneSession,
+                     options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication,
+                     didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {}
+
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+}
+```
+
+Create `<AppName>/SceneDelegate.swift`:
+
+```swift
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene,
+               willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        window = UIWindow(frame: windowScene.coordinateSpace.bounds)
+        window?.windowScene = windowScene
+        window?.rootViewController = UIViewController()
+        window?.makeKeyAndVisible()
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {}
+    func sceneDidBecomeActive(_ scene: UIScene) {}
+    func sceneWillResignActive(_ scene: UIScene) {}
+    func sceneWillEnterForeground(_ scene: UIScene) {}
+    func sceneDidEnterBackground(_ scene: UIScene) {}
+}
+```
+
+---
+
+## Step 2: Create project.yml
+
+Create `project.yml` in the project root (`<OutputDir>/<AppName>/`):
+
+```yaml
+name: <AppName>
+options:
+  bundleIdPrefix: <BundleIdPrefix>   # everything before the last component, e.g. com.mycompany
+  deploymentTarget:
+    iOS: "18.0"
+settings:
+  PRODUCT_BUNDLE_IDENTIFIER: <BundleID>
+targets:
+  <AppName>:
+    type: application
+    platform: iOS
+    sources:
+      - <AppName>
+    info:
+      path: <AppName>/Info.plist
+      properties:
+        UIApplicationSceneManifest:
+          UIApplicationSupportsMultipleScenes: false
+          UISceneConfigurations:
+            UIWindowSceneSessionRoleApplication:
+              - UISceneConfigurationName: Default Configuration
+                UISceneDelegateClassName: $(PRODUCT_MODULE_NAME).SceneDelegate
+```
+
+> **Note:** `UILaunchStoryboardName` is intentionally omitted. Apps created with this skill use a programmatic window setup and do not require a launch storyboard.
+
+---
+
+## Step 3: Generate the Xcode Project
+
+```bash
+cd <OutputDir>/<AppName>
+xcodegen generate
+```
+
+xcodegen will create `<AppName>.xcodeproj` and `<AppName>/Info.plist`. Verify both are present before continuing.
+
+---
+
+## Step 4: Add Salesforce Mobile SDK
+
+Invoke the `add-mobile-sdk-ios` skill now, passing the values collected in the prerequisites.
+
+The skill will:
+- Add the `SalesforceSDKCore` dependency (CocoaPods or SPM)
+- Update `AppDelegate.swift` with `SalesforceManager.initializeSDK()`
+- Update `SceneDelegate.swift` with `AuthHelper.loginIfRequired` and user-change notifications
+- Create `bootconfig.plist`
+- Add `SFDCOAuthLoginHost` to `Info.plist`
+
+For the CocoaPods path, after the skill creates the `Podfile`, run:
+
+```bash
+pod install
+```
+
+Then open `<AppName>.xcworkspace` (not `.xcodeproj`).
+
+For the SPM path, the skill gives instructions to add the package in Xcode — no extra command needed.
+
+---
+
+## Step 5: Build and Verify
+
+```bash
+# CocoaPods
+xcodebuild -workspace <AppName>.xcworkspace \
+  -scheme <AppName> \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  build
+
+# SPM (no workspace)
+xcodebuild -project <AppName>.xcodeproj \
+  -scheme <AppName> \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  build
+```
+
+Expected: `** BUILD SUCCEEDED **`
+
+Run on the simulator — the Salesforce login screen should appear on first launch.
+
+---
+
+## Checklist
+
+- [ ] Project directory created with `<AppName>` subdirectory for sources
+- [ ] `AppDelegate.swift` and `SceneDelegate.swift` created
+- [ ] `project.yml` created with correct bundle ID and deployment target
+- [ ] `xcodegen generate` completed without errors
+- [ ] `add-mobile-sdk-ios` skill applied
+- [ ] `pod install` run (CocoaPods path) or SPM package added in Xcode (SPM path)
+- [ ] Project builds without errors
+- [ ] Salesforce login screen appears on first launch
+
+---
+
+## Troubleshooting
+
+**`xcodegen: command not found`**
+Run `brew install xcodegen`.
+
+**`xcodegen generate` fails with "No project spec found"**
+Ensure `project.yml` is in the current directory when running the command.
+
+**Build fails after `pod install`**
+Open `.xcworkspace`, not `.xcodeproj`. CocoaPods requires the workspace.
+
+For all other issues, refer to the troubleshooting section of the `add-mobile-sdk-ios` skill.


### PR DESCRIPTION
## Summary

- Adds `add-mobile-sdk-ios` skill: integrates Salesforce Mobile SDK authentication into an existing iOS Swift app (CocoaPods or SPM, `SalesforceManager.initializeSDK()`, `AuthHelper.loginIfRequired`, `bootconfig.plist`, `Info.plist`)
- Adds `create-ios-app-with-mobile-sdk` skill: creates a new iOS Swift app from scratch using `xcodegen`, then delegates to `add-mobile-sdk-ios` to wire in the SDK
- Updates `skills/README.md` with both skills in the consumer skills table and a "Testing a Consumer Skill" section

## Test plan

- [ ] Both skills exercised against a real blank app in `/tmp` — `** BUILD SUCCEEDED **` confirmed for both
- [ ] `add-mobile-sdk-ios`: applied to `/tmp/MobileSdkDemo`, built successfully against iPhone 17 Pro simulator
- [ ] `create-ios-app-with-mobile-sdk`: applied to `/tmp/SalesforceHelloWorld`, built successfully against iPhone 17 Pro simulator
- [ ] Run the generated app on a simulator and verify the Salesforce login screen appears on first launch (requires setting a valid Consumer Key and Callback URL in `bootconfig.plist`)