### PR TITLE
Add Android consumer skills: add-mobile-sdk, add-smartstore, add-mobilesync

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -30,6 +30,9 @@ Use the directory/`SKILL.md` format so the `npx skills` CLI can discover and ins
 | `add-mobile-sdk-ios/` | Add Mobile SDK authentication to an existing iOS Swift app |
 | `add-smartstore-ios/` | Add SmartStore (encrypted local database) to an iOS Swift app that already has Mobile SDK |
 | `add-mobilesync-ios/` | Add MobileSync (cloud data sync) to an iOS Swift app that already has SmartStore |
+| `add-mobile-sdk-android/` | Add Mobile SDK authentication to an existing Android Kotlin app |
+| `add-smartstore-android/` | Add SmartStore (encrypted local database) to an Android Kotlin app that already has Mobile SDK |
+| `add-mobilesync-android/` | Add MobileSync (cloud data sync) to an Android Kotlin app that already has SmartStore |
 
 ### SDK developer skills (internal)
 

--- a/.claude/skills/add-mobile-sdk-android/SKILL.md
+++ b/.claude/skills/add-mobile-sdk-android/SKILL.md
@@ -163,16 +163,28 @@ Use the login host provided by the user, or `https://login.salesforce.com` as th
 
 ## Step 6: Update MainActivity.kt
 
-`MainActivity` must extend `SalesforceActivity` so the SDK can manage the OAuth login lifecycle:
+`MainActivity` must extend `SalesforceActivity` so the SDK can manage the OAuth login lifecycle. Add a smoke test UI in `onCreate` to confirm the SDK is working after login:
 
 ```kotlin
 package <AppPackage>
 
-import com.salesforce.androidsdk.app.SalesforceSDKManager
+import android.os.Bundle
+import android.view.Gravity
+import android.widget.TextView
 import com.salesforce.androidsdk.rest.RestClient
 import com.salesforce.androidsdk.ui.SalesforceActivity
 
 class MainActivity : SalesforceActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val label = TextView(this).apply {
+            text = "Mobile SDK ready"
+            gravity = Gravity.CENTER
+            textSize = 18f
+        }
+        setContentView(label)
+    }
 
     override fun onResume(client: RestClient?) {
         // Called after successful login. client is non-null when logged in.
@@ -180,6 +192,8 @@ class MainActivity : SalesforceActivity() {
     }
 }
 ```
+
+After login, you should see **"Mobile SDK ready"** centered on the screen. This is a smoke test placeholder — replace with your real app UI once verified.
 
 > **`onResume(client: RestClient?)`** is called every time the activity resumes with a valid session. It is the correct place to start loading data. `client` is `null` if the user is not authenticated.
 
@@ -207,6 +221,7 @@ Run on an emulator — the Salesforce login screen should appear on first launch
 - [ ] `servers.xml` created with login host
 - [ ] Project builds without errors
 - [ ] Salesforce login screen appears on first launch
+- [ ] "Mobile SDK ready" label is shown after login
 
 ---
 

--- a/.claude/skills/add-mobile-sdk-android/SKILL.md
+++ b/.claude/skills/add-mobile-sdk-android/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: add-mobile-sdk-android
+description: Add Salesforce Mobile SDK to an existing Android Kotlin application. Handles Gradle dependency, SDK initialization in Application class, OAuth login flow via SalesforceActivity, bootconfig.xml, and servers.xml configuration.
+---
+
+# Add Salesforce Mobile SDK to an Android Kotlin App
+
+This skill integrates the Salesforce Mobile SDK into an existing Android Kotlin application, wiring up authentication so users are prompted to log in to Salesforce when the app launches.
+
+## What This Skill Does
+
+1. Adds the `MobileSyncSDKManager` dependency to `app/build.gradle.kts`
+2. Creates `MainApplication.kt` — initializes the SDK on startup
+3. Updates `AndroidManifest.xml` to declare `MainApplication` and use the SDK login theme
+4. Creates `bootconfig.xml` with OAuth configuration
+5. Creates `servers.xml` with the login host
+6. Updates `MainActivity.kt` to extend `SalesforceActivity`
+
+## Prerequisites
+
+Before starting, ask the user for:
+- **App package name** (e.g. `com.example.myapp`)
+- **Main activity class name** (e.g. `MainActivity`)
+- **Consumer Key** (OAuth connected app consumer key, or leave as placeholder)
+- **Callback URL** (OAuth redirect URI, or leave as placeholder)
+- **Login host** (default: `https://login.salesforce.com`, use `https://test.salesforce.com` for sandboxes)
+
+---
+
+## Step 1: Add the SDK Dependency
+
+In `app/build.gradle.kts`, add `MobileSyncSDKManager` via Maven Central. Using `MobileSync` as the single dependency pulls in `SmartStore` and `SalesforceSDKCore` transitively.
+
+```kotlin
+dependencies {
+    implementation("com.salesforce.mobilesdk:MobileSync:13.2.0")
+}
+```
+
+Also ensure the Android build block is configured for SDK compatibility:
+
+```kotlin
+android {
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 28
+        targetSdk = 36
+    }
+
+    buildFeatures {
+        aidl = true
+        renderScript = true
+        buildConfig = true
+    }
+
+    packaging {
+        resources {
+            excludes += setOf(
+                "META-INF/LICENSE",
+                "META-INF/LICENSE.txt",
+                "META-INF/DEPENDENCIES",
+                "META-INF/NOTICE"
+            )
+        }
+    }
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+```
+
+Sync Gradle after editing.
+
+> **Adding SmartStore or MobileSync later?** The `MobileSync` artifact already includes both. There is no separate `SalesforceSDKCore`-only artifact needed for the basic SDK — start with `MobileSync` and stay on it.
+
+---
+
+## Step 2: Create MainApplication.kt
+
+Create `MainApplication.kt` in the app's main package (same directory as `MainActivity.kt`):
+
+```kotlin
+package <AppPackage>
+
+import android.app.Application
+import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager
+
+class MainApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        MobileSyncSDKManager.initNative(applicationContext, MainActivity::class.java)
+    }
+}
+```
+
+`MobileSyncSDKManager.initNative()` must be called before any SDK class is used. It registers the SDK with the Android system and wires up the OAuth login flow, directing the user to `MainActivity` after successful authentication.
+
+---
+
+## Step 3: Update AndroidManifest.xml
+
+Register `MainApplication` and apply the SDK login theme to `MainActivity`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:name=".MainApplication"
+        android:icon="@drawable/sf__icon"
+        android:label="@string/app_name"
+        android:theme="@style/SalesforceSDK">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:theme="@style/SalesforceSDK">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+    </application>
+
+</manifest>
+```
+
+---
+
+## Step 4: Create bootconfig.xml
+
+Create `app/src/main/res/values/bootconfig.xml`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="remoteAccessConsumerKey">YOUR_CONSUMER_KEY</string>
+    <string name="oauthRedirectURI">YOUR_CALLBACK_URL</string>
+</resources>
+```
+
+Replace `YOUR_CONSUMER_KEY` and `YOUR_CALLBACK_URL` with the values from your Salesforce Connected App. If the user provided them in the prerequisites, substitute them now.
+
+---
+
+## Step 5: Create servers.xml
+
+Create `app/src/main/res/xml/servers.xml` (create the `xml/` directory if it doesn't exist):
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<servers>
+    <server name="Default" url="https://login.salesforce.com" />
+</servers>
+```
+
+Use the login host provided by the user, or `https://login.salesforce.com` as the default.
+
+---
+
+## Step 6: Update MainActivity.kt
+
+`MainActivity` must extend `SalesforceActivity` so the SDK can manage the OAuth login lifecycle:
+
+```kotlin
+package <AppPackage>
+
+import com.salesforce.androidsdk.app.SalesforceSDKManager
+import com.salesforce.androidsdk.rest.RestClient
+import com.salesforce.androidsdk.ui.SalesforceActivity
+
+class MainActivity : SalesforceActivity() {
+
+    override fun onResume(client: RestClient?) {
+        // Called after successful login. client is non-null when logged in.
+        // Replace this with your app's post-login logic.
+    }
+}
+```
+
+> **`onResume(client: RestClient?)`** is called every time the activity resumes with a valid session. It is the correct place to start loading data. `client` is `null` if the user is not authenticated.
+
+---
+
+## Step 7: Build and Verify
+
+```bash
+./gradlew assembleDebug
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+Run on an emulator — the Salesforce login screen should appear on first launch.
+
+---
+
+## Checklist
+
+- [ ] `MobileSync` dependency added to `app/build.gradle.kts`
+- [ ] `MainApplication.kt` created and calls `MobileSyncSDKManager.initNative()`
+- [ ] `android:name=".MainApplication"` set in `AndroidManifest.xml`
+- [ ] `MainActivity` extends `SalesforceActivity`
+- [ ] `bootconfig.xml` created with consumer key and callback URL
+- [ ] `servers.xml` created with login host
+- [ ] Project builds without errors
+- [ ] Salesforce login screen appears on first launch
+
+---
+
+## Troubleshooting
+
+**Build error: `Unresolved reference: MobileSyncSDKManager`**
+The `MobileSync` dependency is not added or Gradle sync didn't complete. Add the dependency and sync.
+
+**Login screen does not appear**
+Verify `android:name=".MainApplication"` is set in the `<application>` tag and `MobileSyncSDKManager.initNative()` is called in `onCreate()`.
+
+**`Cannot find symbol SalesforceActivity`**
+The `MobileSync` artifact wasn't synced. Run `./gradlew assembleDebug` to force dependency resolution.
+
+**Build error: `aidl` or `renderScript` feature not found**
+These features require `buildFeatures { aidl = true; renderScript = true }` in the `android` block.

--- a/.claude/skills/add-mobile-sdk-ios/SKILL.md
+++ b/.claude/skills/add-mobile-sdk-ios/SKILL.md
@@ -304,9 +304,33 @@ Also ensure the Scene configuration is present (required for `SceneDelegate` to 
 
 ---
 
-## Step 8: Verify the Integration
+## Step 8: Add a Smoke Test UI
 
-Build and run. On first launch, the Salesforce login screen should appear. After a successful login, `setupRootViewController()` is called.
+Replace the placeholder `setupRootViewController()` with a minimal labeled view so you can confirm the SDK is working after login. This is a temporary smoke test — replace the label and view controller with your real app UI once verified.
+
+```swift
+func setupRootViewController() {
+    let vc = UIViewController()
+    vc.view.backgroundColor = .systemBackground
+    let label = UILabel()
+    label.text = "Mobile SDK ready"
+    label.translatesAutoresizingMaskIntoConstraints = false
+    vc.view.addSubview(label)
+    NSLayoutConstraint.activate([
+        label.centerXAnchor.constraint(equalTo: vc.view.centerXAnchor),
+        label.centerYAnchor.constraint(equalTo: vc.view.centerYAnchor)
+    ])
+    window?.rootViewController = vc
+}
+```
+
+After login, you should see **"Mobile SDK ready"** centered on a white screen.
+
+---
+
+## Step 9: Build and Verify
+
+Build and run. On first launch, the Salesforce login screen should appear. After a successful login, `setupRootViewController()` is called and the label is shown.
 
 ### Checklist
 
@@ -322,7 +346,7 @@ Build and run. On first launch, the Salesforce login screen should appear. After
 - [ ] `remoteAccessConsumerKey` and `oauthRedirectURI` are set in `bootconfig.plist`
 - [ ] `SFDCOAuthLoginHost` is present in `Info.plist`
 - [ ] App prompts for Salesforce login on first launch
-- [ ] `setupRootViewController()` replaced with the real root view controller
+- [ ] "Mobile SDK ready" label is shown after login
 
 ---
 

--- a/.claude/skills/add-mobilesync-android/SKILL.md
+++ b/.claude/skills/add-mobilesync-android/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: add-mobilesync-android
+description: Add Salesforce MobileSync (cloud data sync) to an existing Android Kotlin app that already has SmartStore integrated.
+---
+
+# Add MobileSync to an Android Kotlin App
+
+This skill adds Salesforce MobileSync to an existing Android Kotlin app that already has SmartStore integrated via the `add-smartstore-android` skill.
+
+## What This Skill Does
+
+1. Upgrades SDK initialization back to `MobileSyncSDKManager` (the top of the SDK manager hierarchy)
+2. Calls `MobileSyncSDKManager.getInstance().setupUserSyncsFromDefaultConfig()` after login alongside the existing store setup
+3. Creates `app/src/main/res/raw/usersyncs.json` with placeholder sync definitions
+
+## Prerequisites
+
+The app must already have SmartStore integrated. **Check `MainApplication.kt` for `SmartStoreSDKManager.initNative()` and `MainActivity.kt` for `setupUserStoreFromDefaultConfig()`.** If not present:
+
+1. If the app has no Mobile SDK at all, run `add-mobile-sdk-android` first.
+2. Then run `add-smartstore-android`.
+3. Then return here.
+
+Before starting, confirm:
+- **Soup name** used in `userstore.json` (the sync will target this soup)
+- **Salesforce sObject API name** to sync from (e.g. `Account`, `Contact`) — this is the server-side object, not necessarily the same as the soup name
+
+---
+
+## Step 1: No Dependency Change Needed
+
+`MobileSyncSDKManager` is included in the same `com.salesforce.mobilesdk:MobileSync` artifact already present. No `build.gradle.kts` changes are needed.
+
+---
+
+## Step 2: Upgrade SDK Initialization in MainApplication.kt
+
+Replace `SmartStoreSDKManager` with `MobileSyncSDKManager`:
+
+**Before:**
+```kotlin
+import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager
+
+class MainApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        SmartStoreSDKManager.initNative(applicationContext, MainActivity::class.java)
+    }
+}
+```
+
+**After:**
+```kotlin
+import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager
+
+class MainApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        MobileSyncSDKManager.initNative(applicationContext, MainActivity::class.java)
+    }
+}
+```
+
+> `MobileSyncSDKManager` is a subclass of `SmartStoreSDKManager`. It adds MobileSync support while preserving all SmartStore, OAuth and REST functionality.
+
+---
+
+## Step 3: Add Sync Setup in MainActivity.kt
+
+Add `setupUserSyncsFromDefaultConfig()` alongside the existing store setup call in `onResume`:
+
+**Before:**
+```kotlin
+import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager
+
+override fun onResume(client: RestClient?) {
+    if (client == null) return
+    SmartStoreSDKManager.getInstance().setupUserStoreFromDefaultConfig()
+    // post-login logic
+}
+```
+
+**After:**
+```kotlin
+import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager
+
+override fun onResume(client: RestClient?) {
+    if (client == null) return
+    MobileSyncSDKManager.getInstance().setupUserStoreFromDefaultConfig()
+    MobileSyncSDKManager.getInstance().setupUserSyncsFromDefaultConfig()
+    // post-login logic
+}
+```
+
+---
+
+## Step 4: Create usersyncs.json
+
+Create `app/src/main/res/raw/usersyncs.json` (next to `userstore.json`):
+
+```json
+{
+  "syncs": [
+    {
+      "syncName": "syncDown<SoupName>",
+      "syncType": "syncDown",
+      "soupName": "<SoupName>",
+      "target": {
+        "type": "soql",
+        "query": "SELECT Id, Name FROM <SalesforceObject> LIMIT 100"
+      },
+      "options": {
+        "mergeMode": "LEAVE_IF_CHANGED"
+      }
+    }
+  ]
+}
+```
+
+Replace:
+- `<SoupName>` with the soup name used in `userstore.json` — this is the **local** SmartStore table name
+- `<SalesforceObject>` in the SOQL `FROM` clause with the **Salesforce sObject API name** to sync from (e.g. `Account`, `Contact`) — this query runs on the server
+
+> The soup name and the sObject name are often the same (e.g. soup `Account`, query `FROM Account`) but they don't have to be. The soup is a local storage concept; the SOQL target is a server-side Salesforce object.
+
+The SDK reads `usersyncs.json` automatically from `res/raw/` — no code registration is needed beyond calling `setupUserSyncsFromDefaultConfig()`.
+
+---
+
+## Step 5: Build and Verify
+
+```bash
+./gradlew assembleDebug
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+---
+
+## Checklist
+
+- [ ] `MainApplication.kt` imports `MobileSyncSDKManager` and calls `MobileSyncSDKManager.initNative()`
+- [ ] `onResume()` in `MainActivity.kt` calls both `setupUserStoreFromDefaultConfig()` and `setupUserSyncsFromDefaultConfig()`
+- [ ] `app/src/main/res/raw/usersyncs.json` created with at least one sync targeting the correct soup
+- [ ] SOQL `FROM` clause references a Salesforce sObject, not the local soup name
+- [ ] Project builds without errors
+
+---
+
+## Troubleshooting
+
+**`setupUserSyncsFromDefaultConfig()` silently does nothing**
+`usersyncs.json` must be in `app/src/main/res/raw/`. The SDK resolves it by resource name.
+
+**Sync fails at runtime with "Soup not found"**
+The `soupName` in `usersyncs.json` must exactly match the `soupName` in `userstore.json`.
+
+**`Unresolved reference: MobileSyncSDKManager`**
+Ensure `com.salesforce.mobilesdk:MobileSync` is in the dependencies and Gradle has synced.

--- a/.claude/skills/add-mobilesync-android/SKILL.md
+++ b/.claude/skills/add-mobilesync-android/SKILL.md
@@ -67,11 +67,21 @@ class MainApplication : Application() {
 
 ## Step 3: Add Sync Setup in MainActivity.kt
 
-Add `setupUserSyncsFromDefaultConfig()` alongside the existing store setup call in `onResume`:
+Add `setupUserSyncsFromDefaultConfig()` alongside the existing store setup call in `onResume`. Also update the smoke test label in `onCreate` to reflect MobileSync is now active:
 
 **Before:**
 ```kotlin
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager
+
+override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val label = TextView(this).apply {
+        text = "SmartStore ready"
+        gravity = Gravity.CENTER
+        textSize = 18f
+    }
+    setContentView(label)
+}
 
 override fun onResume(client: RestClient?) {
     if (client == null) return
@@ -82,7 +92,20 @@ override fun onResume(client: RestClient?) {
 
 **After:**
 ```kotlin
+import android.os.Bundle
+import android.view.Gravity
+import android.widget.TextView
 import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager
+
+override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val label = TextView(this).apply {
+        text = "SmartStore + MobileSync ready"
+        gravity = Gravity.CENTER
+        textSize = 18f
+    }
+    setContentView(label)
+}
 
 override fun onResume(client: RestClient?) {
     if (client == null) return
@@ -91,6 +114,8 @@ override fun onResume(client: RestClient?) {
     // post-login logic
 }
 ```
+
+After login, you should see **"SmartStore + MobileSync ready"** centered on the screen. This is a smoke test placeholder — replace with your real app UI once verified.
 
 ---
 
@@ -140,10 +165,12 @@ Expected: `BUILD SUCCESSFUL`
 ## Checklist
 
 - [ ] `MainApplication.kt` imports `MobileSyncSDKManager` and calls `MobileSyncSDKManager.initNative()`
+- [ ] `onCreate()` in `MainActivity.kt` shows the "SmartStore + MobileSync ready" smoke test label
 - [ ] `onResume()` in `MainActivity.kt` calls both `setupUserStoreFromDefaultConfig()` and `setupUserSyncsFromDefaultConfig()`
 - [ ] `app/src/main/res/raw/usersyncs.json` created with at least one sync targeting the correct soup
 - [ ] SOQL `FROM` clause references a Salesforce sObject, not the local soup name
 - [ ] Project builds without errors
+- [ ] "SmartStore + MobileSync ready" label is shown after login
 
 ---
 

--- a/.claude/skills/add-mobilesync-ios/SKILL.md
+++ b/.claude/skills/add-mobilesync-ios/SKILL.md
@@ -125,9 +125,21 @@ import SalesforceSDKCore   // keep this — AuthHelper lives here
 func setupRootViewController() {
     MobileSyncSDKManager.shared.setupUserStoreFromDefaultConfig()
     MobileSyncSDKManager.shared.setupUserSyncsFromDefaultConfig()
-    window?.rootViewController = UIViewController()
+    let vc = UIViewController()
+    vc.view.backgroundColor = .systemBackground
+    let label = UILabel()
+    label.text = "SmartStore + MobileSync ready"
+    label.translatesAutoresizingMaskIntoConstraints = false
+    vc.view.addSubview(label)
+    NSLayoutConstraint.activate([
+        label.centerXAnchor.constraint(equalTo: vc.view.centerXAnchor),
+        label.centerYAnchor.constraint(equalTo: vc.view.centerYAnchor)
+    ])
+    window?.rootViewController = vc
 }
 ```
+
+After login, you should see **"SmartStore + MobileSync ready"** centered on the screen. This is a smoke test placeholder — replace with your real app UI once verified.
 
 ---
 
@@ -198,6 +210,7 @@ Expected: `** BUILD SUCCEEDED **`
 - [ ] `usersyncs.json` created with at least one sync definition targeting the correct soup
 - [ ] `usersyncs.json` is in the **Copy Bundle Resources** build phase
 - [ ] Project builds without errors
+- [ ] "SmartStore + MobileSync ready" label is shown after login
 
 ---
 

--- a/.claude/skills/add-smartstore-android/SKILL.md
+++ b/.claude/skills/add-smartstore-android/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: add-smartstore-android
+description: Add Salesforce SmartStore (encrypted local database) to an existing Android Kotlin app that already has the Mobile SDK integrated.
+---
+
+# Add SmartStore to an Android Kotlin App
+
+This skill adds the Salesforce SmartStore encrypted local database to an existing Android Kotlin app that already has the Mobile SDK integrated via the `add-mobile-sdk-android` skill.
+
+## What This Skill Does
+
+1. Upgrades SDK initialization from `MobileSyncSDKManager` to `SmartStoreSDKManager` (no dependency change required — both are in the same artifact)
+2. Calls `SmartStoreSDKManager.getInstance().setupUserStoreFromDefaultConfig()` after login
+3. Creates `app/src/main/res/raw/userstore.json` with a placeholder soup
+
+## Prerequisites
+
+The app must already have the Mobile SDK wired up. **Check `MainApplication.kt` for `MobileSyncSDKManager.initNative()` or `SmartStoreSDKManager.initNative()`.** If not present, run the `add-mobile-sdk-android` skill first, then return here.
+
+Before starting, confirm:
+- **App package name** (e.g. `com.example.myapp`)
+- **Soup name** for the initial store table (default: `Item`)
+
+---
+
+## Step 1: No Dependency Change Needed
+
+`SmartStoreSDKManager` is included in the same `com.salesforce.mobilesdk:MobileSync` artifact already present. No `build.gradle.kts` changes are needed.
+
+---
+
+## Step 2: Upgrade SDK Initialization in MainApplication.kt
+
+Replace `MobileSyncSDKManager` with `SmartStoreSDKManager`:
+
+**Before:**
+```kotlin
+import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager
+
+class MainApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        MobileSyncSDKManager.initNative(applicationContext, MainActivity::class.java)
+    }
+}
+```
+
+**After:**
+```kotlin
+import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager
+
+class MainApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        SmartStoreSDKManager.initNative(applicationContext, MainActivity::class.java)
+    }
+}
+```
+
+> `SmartStoreSDKManager` is a subclass of `SalesforceSDKManager`. It adds SmartStore support while preserving all OAuth and REST functionality.
+
+---
+
+## Step 3: Set Up the Store After Login in MainActivity.kt
+
+Call `setupUserStoreFromDefaultConfig()` in `onResume`:
+
+**Before:**
+```kotlin
+override fun onResume(client: RestClient?) {
+    // post-login logic
+}
+```
+
+**After:**
+```kotlin
+import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager
+
+override fun onResume(client: RestClient?) {
+    if (client == null) return
+    SmartStoreSDKManager.getInstance().setupUserStoreFromDefaultConfig()
+    // post-login logic
+}
+```
+
+---
+
+## Step 4: Create userstore.json
+
+Create `app/src/main/res/raw/userstore.json` (create the `raw/` directory if it doesn't exist):
+
+```json
+{
+  "soups": [
+    {
+      "soupName": "<SoupName>",
+      "indexes": [
+        { "path": "Id",        "type": "string" },
+        { "path": "Name",      "type": "string" },
+        { "path": "__local__", "type": "string" }
+      ]
+    }
+  ]
+}
+```
+
+Replace `<SoupName>` with the soup name agreed with the user (default: `Item`).
+
+The SDK reads `userstore.json` automatically from `res/raw/` — no code registration is needed beyond calling `setupUserStoreFromDefaultConfig()`.
+
+---
+
+## Step 5: Build and Verify
+
+```bash
+./gradlew assembleDebug
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+---
+
+## Checklist
+
+- [ ] `MainApplication.kt` imports `SmartStoreSDKManager` and calls `SmartStoreSDKManager.initNative()`
+- [ ] `onResume()` in `MainActivity.kt` calls `setupUserStoreFromDefaultConfig()`
+- [ ] `app/src/main/res/raw/userstore.json` created with at least one soup
+- [ ] Project builds without errors
+
+---
+
+## Troubleshooting
+
+**`setupUserStoreFromDefaultConfig()` silently does nothing**
+`userstore.json` must be in `app/src/main/res/raw/` (not `assets/`, not `res/values/`). The SDK resolves it by resource name.
+
+**`Unresolved reference: SmartStoreSDKManager`**
+Ensure `com.salesforce.mobilesdk:MobileSync` is in the dependencies and Gradle has synced.

--- a/.claude/skills/add-smartstore-android/SKILL.md
+++ b/.claude/skills/add-smartstore-android/SKILL.md
@@ -63,7 +63,7 @@ class MainApplication : Application() {
 
 ## Step 3: Set Up the Store After Login in MainActivity.kt
 
-Call `setupUserStoreFromDefaultConfig()` in `onResume`:
+Call `setupUserStoreFromDefaultConfig()` in `onResume`. Also add a smoke test UI in `onCreate` so you can confirm SmartStore is initializing after login:
 
 **Before:**
 ```kotlin
@@ -74,7 +74,20 @@ override fun onResume(client: RestClient?) {
 
 **After:**
 ```kotlin
+import android.os.Bundle
+import android.view.Gravity
+import android.widget.TextView
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager
+
+override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val label = TextView(this).apply {
+        text = "SmartStore ready"
+        gravity = Gravity.CENTER
+        textSize = 18f
+    }
+    setContentView(label)
+}
 
 override fun onResume(client: RestClient?) {
     if (client == null) return
@@ -82,6 +95,8 @@ override fun onResume(client: RestClient?) {
     // post-login logic
 }
 ```
+
+After login, you should see **"SmartStore ready"** centered on the screen. This is a smoke test placeholder — replace with your real app UI once verified.
 
 ---
 
@@ -123,9 +138,11 @@ Expected: `BUILD SUCCESSFUL`
 ## Checklist
 
 - [ ] `MainApplication.kt` imports `SmartStoreSDKManager` and calls `SmartStoreSDKManager.initNative()`
+- [ ] `onCreate()` in `MainActivity.kt` shows the "SmartStore ready" smoke test label
 - [ ] `onResume()` in `MainActivity.kt` calls `setupUserStoreFromDefaultConfig()`
 - [ ] `app/src/main/res/raw/userstore.json` created with at least one soup
 - [ ] Project builds without errors
+- [ ] "SmartStore ready" label is shown after login
 
 ---
 

--- a/.claude/skills/add-smartstore-ios/SKILL.md
+++ b/.claude/skills/add-smartstore-ios/SKILL.md
@@ -104,7 +104,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 ## Step 3: Set Up the Store After Login in SceneDelegate.swift
 
-Add a `SmartStore` import and call `setupUserStoreFromDefaultConfig()` inside `setupRootViewController()`.
+Add a `SmartStore` import and call `setupUserStoreFromDefaultConfig()` inside `setupRootViewController()`. Also add a smoke test label so you can confirm SmartStore is initializing correctly.
 
 **Before:**
 ```swift
@@ -126,9 +126,21 @@ import SalesforceSDKCore   // keep this — AuthHelper lives here
 
 func setupRootViewController() {
     SmartStoreSDKManager.shared.setupUserStoreFromDefaultConfig()
-    window?.rootViewController = UIViewController()
+    let vc = UIViewController()
+    vc.view.backgroundColor = .systemBackground
+    let label = UILabel()
+    label.text = "SmartStore ready"
+    label.translatesAutoresizingMaskIntoConstraints = false
+    vc.view.addSubview(label)
+    NSLayoutConstraint.activate([
+        label.centerXAnchor.constraint(equalTo: vc.view.centerXAnchor),
+        label.centerYAnchor.constraint(equalTo: vc.view.centerYAnchor)
+    ])
+    window?.rootViewController = vc
 }
 ```
+
+After login, you should see **"SmartStore ready"** centered on the screen. This is a smoke test placeholder — replace with your real app UI once verified.
 
 ---
 
@@ -191,6 +203,7 @@ Expected: `** BUILD SUCCEEDED **`
 - [ ] `userstore.json` created with at least one soup
 - [ ] `userstore.json` is in the **Copy Bundle Resources** build phase
 - [ ] Project builds without errors
+- [ ] "SmartStore ready" label is shown after login
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds 3 Claude Code consumer skills for Android Kotlin developers:
  - `add-mobile-sdk-android`: Add Mobile SDK authentication to an existing Android Kotlin app
  - `add-smartstore-android`: Add SmartStore (encrypted local database) to an Android Kotlin app that already has Mobile SDK
  - `add-mobilesync-android`: Add MobileSync (cloud data sync) to an Android Kotlin app that already has SmartStore
- Adds a smoke test UI step to all 6 consumer skills (3 iOS + 3 Android) for consistent verification
- Updates skills README table to include the 3 new Android skills

## Test plan

- [ ] Run `add-mobile-sdk-android` skill on a fresh Android Kotlin app and verify Mobile SDK auth works
- [ ] Run `add-smartstore-android` skill and verify SmartStore CRUD operations work
- [ ] Run `add-mobilesync-android` skill and verify data syncs with Salesforce
- [ ] Verify smoke test UI step works correctly in each skill
- [ ] Confirm skills README table accurately reflects all 6 consumer skills